### PR TITLE
Fix UnconsumedResultTest on modern compilers

### DIFF
--- a/test/CountingBoostAssert.hpp
+++ b/test/CountingBoostAssert.hpp
@@ -8,13 +8,9 @@
 
 
 
-#include <string>
-#include <stdexcept>
-
-
-
 #define BOOST_ENABLE_ASSERT_HANDLER
 
+unsigned int sc_assert_failure_count(0U);
 
 
 namespace boost
@@ -22,12 +18,9 @@ namespace boost
 
 
 void assertion_failed(
-  char const * expr, char const * func, char const * file, long )
+  char const *, char const *, char const *, long )
 {
-  throw std::logic_error(
-    std::string( "\nAssertion failed: \"" ) + expr + "\"\n" +
-    "File: \"" + file + "\"\n" +
-    "Function: \"" + func + "\"\n" );
+  ++sc_assert_failure_count;
 }
 
 

--- a/test/InvalidResultCopyTest.cpp
+++ b/test/InvalidResultCopyTest.cpp
@@ -6,7 +6,7 @@
 
 
 
-#include <libs/statechart/test/ThrowingBoostAssert.hpp>
+#include "CountingBoostAssert.hpp"
 #include <boost/statechart/state_machine.hpp>
 #include <boost/statechart/event.hpp>
 #include <boost/statechart/simple_state.hpp>
@@ -14,8 +14,6 @@
 #include <boost/statechart/result.hpp>
 
 #include <boost/test/test_tools.hpp>
-
-#include <stdexcept> // std::logic_error
 
 namespace sc = boost::statechart;
 
@@ -51,11 +49,13 @@ int test_main( int, char* [] )
 {
   InvalidResultCopyTest machine;
   machine.initiate();
+  BOOST_REQUIRE_EQUAL( sc_assert_failure_count, 0U );
 
+  machine.process_event( E() );
   #ifdef NDEBUG
-    BOOST_REQUIRE_NO_THROW( machine.process_event( E() ) );
+    BOOST_REQUIRE_EQUAL( sc_assert_failure_count, 0U );
   #else
-    BOOST_REQUIRE_THROW( machine.process_event( E() ), std::logic_error );
+    BOOST_REQUIRE_EQUAL( sc_assert_failure_count, 2U );
   #endif
 
   return 0;

--- a/test/UnconsumedResultTest.cpp
+++ b/test/UnconsumedResultTest.cpp
@@ -6,12 +6,10 @@
 
 
 
-#include <libs/statechart/test/ThrowingBoostAssert.hpp>
+#include "CountingBoostAssert.hpp"
 #include <boost/statechart/result.hpp>
 
 #include <boost/test/test_tools.hpp>
-
-#include <stdexcept> // std::logic_error
 
 
 
@@ -29,14 +27,13 @@ void make_unconsumed_result()
   sc::detail::result_utility::make_result( sc::detail::do_discard_event );
 }
 
-// TODO: The current test setup lets an exception propagate out of a
-// destructor. Find a better way to test this.
 int test_main( int, char* [] )
 {
+  make_unconsumed_result();
   #ifdef NDEBUG
-    BOOST_REQUIRE_NO_THROW( make_unconsumed_result() );
+    BOOST_REQUIRE_EQUAL( sc_assert_failure_count, 0U );
   #else
-    BOOST_REQUIRE_THROW( make_unconsumed_result(), std::logic_error );
+    BOOST_REQUIRE_EQUAL( sc_assert_failure_count, 1U );
   #endif
 
   return 0;


### PR DESCRIPTION
This test relied on a destructor throwing an exception in debug mode, which crashed the program on modern compilers. Now the custom assert handler for the regression tests increments a counter instead of throwing an exception.

Tested on Visual C++ 14 CTP6.

The failing tests are the four UnconsumedResultTest\* on msvc-14.0, clang- darwin-11, clang- darwin-14, and all the "BP x86_64 C++11" testers:
http://www.boost.org/development/tests/develop/developer/statechart.html
