### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/example/PingPong/Player.hpp
+++ b/example/PingPong/Player.hpp
@@ -70,7 +70,7 @@ typedef boost::fast_pool_allocator< int > MyAllocator;
 typedef sc::fifo_scheduler< 
   sc::fifo_worker< MyAllocator >, MyAllocator > MyScheduler;
 #else
-typedef std::allocator< void > MyAllocator;
+typedef std::allocator< sc::none > MyAllocator;
 typedef sc::fifo_scheduler<> MyScheduler;
 #endif
 

--- a/include/boost/statechart/asynchronous_state_machine.hpp
+++ b/include/boost/statechart/asynchronous_state_machine.hpp
@@ -31,7 +31,7 @@ class event_base;
 template< class MostDerived,
           class InitialState,
           class Scheduler = fifo_scheduler<>,
-          class Allocator = std::allocator< void >,
+          class Allocator = std::allocator< none >,
           class ExceptionTranslator = null_exception_translator >
 class asynchronous_state_machine : public state_machine<
   MostDerived, InitialState, Allocator, ExceptionTranslator >,

--- a/include/boost/statechart/event.hpp
+++ b/include/boost/statechart/event.hpp
@@ -26,7 +26,7 @@ namespace statechart
 
 
 //////////////////////////////////////////////////////////////////////////////
-template< class MostDerived, class Allocator = std::allocator< void > >
+template< class MostDerived, class Allocator = std::allocator< none > >
 class event : public detail::rtti_policy::rtti_derived_type<
   MostDerived, event_base >
 {

--- a/include/boost/statechart/fifo_scheduler.hpp
+++ b/include/boost/statechart/fifo_scheduler.hpp
@@ -28,7 +28,7 @@ namespace statechart
 //////////////////////////////////////////////////////////////////////////////
 template<
   class FifoWorker = fifo_worker<>,
-  class Allocator = std::allocator< void > >
+  class Allocator = std::allocator< none > >
 class fifo_scheduler : noncopyable
 {
   typedef processor_container<

--- a/include/boost/statechart/fifo_worker.hpp
+++ b/include/boost/statechart/fifo_worker.hpp
@@ -52,7 +52,7 @@ namespace statechart
 
 
 
-template< class Allocator = std::allocator< void > >
+template< class Allocator = std::allocator< none > >
 class fifo_worker : noncopyable
 {
   public:

--- a/include/boost/statechart/processor_container.hpp
+++ b/include/boost/statechart/processor_container.hpp
@@ -60,7 +60,7 @@ namespace detail
 template<
   class Scheduler,
   class WorkItem,
-  class Allocator = std::allocator< void > >
+  class Allocator = std::allocator< none > >
 class processor_container : noncopyable
 {
   typedef event_processor< Scheduler > processor_base_type;

--- a/include/boost/statechart/state_machine.hpp
+++ b/include/boost/statechart/state_machine.hpp
@@ -230,7 +230,7 @@ class history_key
 //////////////////////////////////////////////////////////////////////////////
 template< class MostDerived,
           class InitialState,
-          class Allocator = std::allocator< void >,
+          class Allocator = std::allocator< none >,
           class ExceptionTranslator = null_exception_translator >
 class state_machine : noncopyable
 {

--- a/test/TransitionTest.cpp
+++ b/test/TransitionTest.cpp
@@ -145,7 +145,7 @@ template< class M > struct S0;
 template< class Translator >
 struct TransitionTest : sc::state_machine<
   TransitionTest< Translator >, S0< TransitionTest< Translator > >,
-  std::allocator< void >, Translator >
+  std::allocator< sc::none >, Translator >
 {
   public:
     //////////////////////////////////////////////////////////////////////////

--- a/test/TriggeringEventTest.cpp
+++ b/test/TriggeringEventTest.cpp
@@ -32,7 +32,7 @@ struct EvDoIt : sc::event< EvDoIt > {};
 struct A;
 struct TriggringEventTest : sc::state_machine<
   TriggringEventTest, A,
-  std::allocator< void >, sc::exception_translator<> >
+  std::allocator< sc::none >, sc::exception_translator<> >
 {
   void Transit(const EvGoToB &)
   {


### PR DESCRIPTION
Replace them by their cousins from std::allocator_traits. In addition to that, std::allocator&lt;void&gt; (used as default argument to the 'Alloc' template parameter of some public types) is deprecated too, and needs some sort of emulation. The emulation type is a mere placeholder without ever being used. Without that, heaps of deprecation warnings will fall onto humble users when compiling with MSVC 15 in C++17 mode.

This fixes #7 