### PR TITLE
Resolve test linking errors on non-Windows systems

### DIFF
--- a/test/TuTest.hpp
+++ b/test/TuTest.hpp
@@ -13,13 +13,11 @@
 
 #include <boost/config.hpp>
 
-#ifdef BOOST_HAS_DECLSPEC
-  #ifdef BOOST_STATECHART_TEST_DYNAMIC_LINK
-    #ifdef BOOST_STATECHART_TEST_DLL_EXPORT
-      #define BOOST_STATECHART_DECL __declspec(dllexport)
-    #else
-      #define BOOST_STATECHART_DECL __declspec(dllimport)
-    #endif
+#ifdef BOOST_STATECHART_TEST_DYNAMIC_LINK
+  #ifdef BOOST_STATECHART_TEST_DLL_EXPORT
+    #define BOOST_STATECHART_DECL BOOST_SYMBOL_EXPORT
+  #else
+    #define BOOST_STATECHART_DECL BOOST_SYMBOL_IMPORT
   #endif
 #endif
 


### PR DESCRIPTION
This PR only fixes the linking problem. The DllTestNormal test still fails at runtime, but, as fas as I understand, this test should not work on Windows either. boost/statechart/detail/rtti_policy.hpp in non-RTTI mode needs to be reworked to fix this test.

Related to https://github.com/boostorg/statechart/issues/9.