### PR TITLE
Update rationale.html, add link to article for downloading

### DIFF
--- a/doc/rationale.html
+++ b/doc/rationale.html
@@ -177,9 +177,10 @@
     whole layout of a state machine can be defined at runtime ("layout"
     refers to states and transitions, actions are still specified with normal
     C++ code). That is, data only available at runtime can be used to build
-    arbitrarily large machines. See "A Multiple Substring Search Algorithm"
-    by Moishe Halibard and Moshe Rubin in June 2002 issue of CUJ for a good
-    example (unfortunately not available online).</li>
+    arbitrarily large machines. See "<a href=
+    "https://www.researchgate.net/publication/293741100_A_multiple_substring_search_algorithm">A 
+    Multiple Substring Search Algorithm</a>" by Moishe Halibard and Moshe Rubin 
+    in June 2002 issue of CUJ for a good example.
 
     <li>On the other side are state machine frameworks which require the
     layout to be specified at compile time</li>


### PR DESCRIPTION
The page lamented the fact that the article "A Multiple Substring Search Algorithm" (Halibard / Rubin) was not available on the web.  In fact, it can be accessed from several sites, the nicest one (in color) being ResearchGate, which I have updated on the page.

There is another URL: (http://www.mountainvistasoft.com/personal/articles/halibard-rubin-cuj-june-2002.pdf), which could be added as an additional cached copy on the web.