### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(boost_statechart
     Boost::function
     Boost::mpl
     Boost::smart_ptr
-    Boost::static_assert
     Boost::thread
     Boost::type_traits
 )

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ constant boost_dependencies :
     /boost/function//boost_function
     /boost/mpl//boost_mpl
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/thread//boost_thread
     /boost/type_traits//boost_type_traits ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.